### PR TITLE
Change min supported version of nexus to 3.28.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,5 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build and verify with default nexus version
         run: mvn -B verify --file pom.xml
-      - name: Build and verify with nexus 3.27.0
-        run: mvn -B  -Dtest.target.nexus.version=3.27.0 verify --file pom.xml
+      - name: Build and verify with nexus 3.30.0
+        run: mvn -B -Dtest.target.nexus.version=3.30.0 verify --file pom.xml

--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ Content-Type: application/json
 ]
 ```
 
-# Compatibility
-Minimum supported version of nexus is 3.15.1-01 at the moment. These versions have been tested:
-* 3.15.1
-* 3.27.0
+# Compatibility Matrix
 
-Plugin may work with other versions, but it hasn't been tested yet.
+| Plugin Version | Nexus Version                    | Tested Nexus Versions |
+| -------------- |:--------------------------------:|:---------------------:|
+| 1.1.0          | &gt;= 3.15.1 <br> &lt; 3.28.0     | 3.15.1 <br> 3.27.0   | 
+| 1.2.0          | &gt;= 3.28.0                      | 3.28.0 <br> 3.30.0   | 
+
 
 # License
 This project is licensed under the Apache License - see the LICENSE.md file for details

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.14.3</version>
+            <version>1.15.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>ir.sahab</groupId>
     <artifactId>nexus-tag-plugin</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <packaging>bundle</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <nexus.version>3.15.1-01</nexus.version>
-        <test.target.nexus.version>3.15.1</test.target.nexus.version>
+        <nexus.version>3.28.0-01</nexus.version>
+        <test.target.nexus.version>3.28.0</test.target.nexus.version>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +52,7 @@
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-validator-provider-11</artifactId>
+            <artifactId>resteasy-validator-provider</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/ir/sahab/nexus/plugin/tag/UpgradeTest.java
+++ b/src/test/java/ir/sahab/nexus/plugin/tag/UpgradeTest.java
@@ -52,7 +52,7 @@ public class UpgradeTest {
     @Test
     public void testUpgrade() throws Exception {
         // Start old version
-        startNexus("3.15.1");
+        startNexus("3.28.0");
 
         // Add Tags
         String tagName = "test-tag";
@@ -63,7 +63,7 @@ public class UpgradeTest {
         response.close();
 
         // Upgrade nexus
-        startNexus("3.27.0");
+        startNexus("3.30.0");
 
         // Check if tag already exists.
         response = tagTarget().path(tagName).request().get();


### PR DESCRIPTION
+ Due to some backward-incompatible changes of nexus internal APIs (NEXUS-25336),
  to use plugin in versions newer than 3.28.0, plugin must be compiled with
  nexus NEXUS-25336 dependency.